### PR TITLE
Log IpAddress and times of visits to shortened urls

### DIFF
--- a/urlshortener/controller.go
+++ b/urlshortener/controller.go
@@ -175,7 +175,7 @@ func (c *Controller) GetLongURL(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	longURL, err := c.service.GetLongURL(shortURL, false)
+	longURL, err := c.service.GetLongURL(shortURL, "")
 	if err != nil {
 		SendError(w, err)
 		return
@@ -191,7 +191,8 @@ func (c *Controller) GetLongURL(w http.ResponseWriter, req *http.Request) {
 
 func (c *Controller) RedirectToLongURL(w http.ResponseWriter, req *http.Request) {
 
-	longURL, err := c.service.GetLongURL(req.URL, true)
+	trackIp := req.Header.Get("X-Forwarded-For")
+	longURL, err := c.service.GetLongURL(req.URL, trackIp)
 
 	fmt.Printf("redirecting to %s\n", longURL)
 

--- a/urlshortener/errors.go
+++ b/urlshortener/errors.go
@@ -8,11 +8,11 @@ import (
 
 const (
 	//Shortening URL
-	ShortenURLDecoding           err.Code = 10200
-	ShortenURLValidation                  = 10300
-	ShortenURLFailedToSave                = 10400
-	ShortenURLSaveVisitTimeError          = 10401
-	ShortenURLUndocumented                = 10999
+	ShortenURLDecoding        err.Code = 10200
+	ShortenURLValidation               = 10300
+	ShortenURLFailedToSave             = 10400
+	ShortenURLTrackVisitError          = 10401
+	ShortenURLUndocumented             = 10999
 
 	//Retrieving Long Url
 	RetrieveFullURLDecoding     = 11200

--- a/urlshortener/service.go
+++ b/urlshortener/service.go
@@ -67,7 +67,7 @@ func buildShortenedURL(reqURL *url.URL, urlRecord *URLRecord) *url.URL {
 	}
 }
 
-func (s *Service) GetLongURL(shortURL *url.URL, trackVisit bool) (*url.URL, err.Err) {
+func (s *Service) GetLongURL(shortURL *url.URL, trackIp string) (*url.URL, err.Err) {
 
 	var shortId string
 	path := shortURL.Path
@@ -92,12 +92,16 @@ func (s *Service) GetLongURL(shortURL *url.URL, trackVisit bool) (*url.URL, err.
 		)
 	}
 
-	if trackVisit {
-		err = s.repo.TrackVisit(shortId)
+	if len(trackIp) >= 0 {
+		err = s.repo.TrackVisit(&VisitTrack{
+			IpAddress:  trackIp,
+			ShortId:    shortId,
+			CreateTime: time.Now(),
+		})
 		if err != nil {
 			return nil, NewError(
-				ShortenURLSaveVisitTimeError,
-				fmt.Sprintf("Failed to add visit time for %s", shortId),
+				ShortenURLTrackVisitError,
+				fmt.Sprintf("Failed to track visit for %s", shortId),
 				map[string]string{"error": err.Error()},
 			)
 		}

--- a/urlshortener/tests/controller_test.go
+++ b/urlshortener/tests/controller_test.go
@@ -45,7 +45,6 @@ func (suite *ControllerSuite) SetupTest() {
 	suite.record = &u.URLRecord{
 		SAVED_LONG_URL,
 		SAVED_SHORT_ID,
-		[]time.Time{},
 		time.Now(),
 	}
 

--- a/urlshortener/tests/service_test.go
+++ b/urlshortener/tests/service_test.go
@@ -46,7 +46,6 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.record = &u.URLRecord{
 		SAVED_LONG_URL,
 		SAVED_SHORT_ID,
-		[]time.Time{},
 		time.Now(),
 	}
 
@@ -108,7 +107,7 @@ func (suite *ServiceSuite) TestShortUrlErrorWhenShortIDNotUnique() {
 func (suite *ServiceSuite) TestGetLongURLErrorWhenShortURLHasNoPath() {
 
 	testUrl, _ := url.Parse("http://www.small.ml")
-	_, err := suite.service.GetLongURL(testUrl, false)
+	_, err := suite.service.GetLongURL(testUrl, "")
 	expectation := error.Code(u.RetrieveFullURLValidation)
 
 	assert.True(suite.T(), err != nil && err.Code() == expectation, "GetLongURL wrong error code. Expected '%d'. Got: %d", expectation, err)
@@ -117,7 +116,7 @@ func (suite *ServiceSuite) TestGetLongURLErrorWhenShortURLHasNoPath() {
 func (suite *ServiceSuite) TestGetLongURLErrorWhenRecordDoesNotExist() {
 
 	testUrl, _ := url.Parse("http://www.small.ml/nil")
-	_, err := suite.service.GetLongURL(testUrl, false)
+	_, err := suite.service.GetLongURL(testUrl, "")
 	expectation := error.Code(u.RetrieveFullURLNotFound)
 
 	assert.True(suite.T(), err != nil && err.Code() == expectation, "GetLongURL wrong error code. Expected '%d'. Got: %d", expectation, err)
@@ -127,7 +126,7 @@ func (suite *ServiceSuite) TestGetLongURLErrorWhenRecordDoesNotExist() {
 func (suite *ServiceSuite) TestGetLongURLWhenRecordExists() {
 
 	testUrl, _ := url.Parse(SAVED_SHORT_URL)
-	url, _ := suite.service.GetLongURL(testUrl, false)
+	url, _ := suite.service.GetLongURL(testUrl, "")
 
 	assert.Equal(suite.T(), url.String(), SAVED_LONG_URL, "GetLongURL returned wrong original url. Expected %s, Got: %s", SAVED_LONG_URL, url.String())
 }
@@ -137,7 +136,6 @@ func (suite *ServiceSuite) TestGetLongURLWhenRecordExists() {
 // 	record := &u.URLRecord{
 // 		"",
 // 		"wrong",
-// 		[]time.Time{},
 // 		time.Now(),
 // 	}
 
@@ -147,6 +145,6 @@ func (suite *ServiceSuite) TestGetLongURLWhenRecordExists() {
 // 		panic(err)
 // 	}
 
-// 	_, err2 := suite.service.GetLongURL(testUrl, false)
+// 	_, err2 := suite.service.GetLongURL(testUrl, "")
 // 	assert.Equal(suite.T(), err2.Code(), u.RetrieveFullURLParsing, "GetLongURL wrong error code. Expected '%d'. Got: %d", u.RetrieveFullURLParsing, err2.Code())
 // }


### PR DESCRIPTION
- Create seperate collection to log visits
- Remove visitTimes array from URLRecord collections
- Update integration tests