### PR TITLE
Replace log.Panic with log.Fatal in urlRepository

### DIFF
--- a/urlshortener/urlRepository.go
+++ b/urlshortener/urlRepository.go
@@ -112,6 +112,6 @@ func isConnectionError(err error) bool {
 
 func panicIfConnectionError(err error) {
 	if isConnectionError(err) {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
The goal is to exit the app in case the database connection fails so that docker
can automatically restart the container.
Panic does not restart the container. Fatal does.